### PR TITLE
sync upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shares now use `vsss_rs::DefaultShare` instead of byte sequences
 - Old share format is deprecate that used byte sequences
 - Fix inner_types exports to not clash with other crates
+- Add conversion methods for Shares to the newer format.
 
 ## v2.5.3 - 2023-10-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 name = "blsful"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/blsful"
-version = "3.0.0-pre7"
+version = "3.0.0-pre8"
 
 [features]
 default = ["blst"]
@@ -24,7 +24,6 @@ blst = ["blstrs_plus"]
 
 [dependencies]
 anyhow = "1.0"
-arrayref = "0.3"
 bls12_381_plus =  { version = "0.8", optional = true }
 blstrs_plus = { version = "0.8", optional = true}
 hex = "0.4"
@@ -41,7 +40,7 @@ sha3 = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
 thiserror = "2.0"
 uint-zigzag = { version = "0.2", features = ["std"] }
-vsss-rs = { version = "5.0.0-rc1", features = ["serde"]  }
+vsss-rs = { version = "5.0.0-rc2", features = ["serde"]  }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 name = "blsful"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/blsful"
-version = "3.0.0-pre6"
+version = "3.0.0-pre7"
 
 [features]
 default = ["blst"]
@@ -39,9 +39,9 @@ serde_bare = "0.5"
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
-thiserror = "1.0"
+thiserror = "2.0"
 uint-zigzag = { version = "0.2", features = ["std"] }
-vsss-rs = { version = "5.0.0-rc1", features = ["serde"], path = "../vsss-rs" }
+vsss-rs = { version = "5.0.0-rc1", features = ["serde"]  }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 name = "blsful"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/blsful"
-version = "3.0.0-pre8"
+version = "3.0.0"
 
 [features]
 default = ["blst"]
@@ -40,7 +40,7 @@ sha3 = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
 thiserror = "2.0"
 uint-zigzag = { version = "0.2", features = ["std"] }
-vsss-rs = { version = "5.0.0-rc2", features = ["serde"]  }
+vsss-rs = { version = "5.1.0", features = ["serde"]  }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -192,9 +192,9 @@ pub mod inner_types {
             cofactor::*, prime::*, Curve, Group, GroupEncoding, GroupOps, GroupOpsOwned, ScalarMul,
             ScalarMulOwned, UncompressedEncoding,
         },
-        multi_miller_loop, pairing, Bls12381G1 as InnerBls12381G1, Bls12381G2 as InnerBls12381G2,
-        G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Gt, MillerLoopResult, Scalar,
-        ScalarLe,
+        multi_miller_loop, pairing, Bls12, Bls12381G1 as InnerBls12381G1,
+        Bls12381G2 as InnerBls12381G2, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective,
+        Gt, MillerLoopResult, Scalar, ScalarLe,
     };
     #[cfg(feature = "blst")]
     pub use blstrs_plus::{
@@ -208,7 +208,7 @@ pub mod inner_types {
         },
         multi_miller_loop, pairing,
         pairing_lib::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine},
-        Bls12381G1 as InnerBls12381G1, Bls12381G2 as InnerBls12381G2, G1Affine, G1Compressed,
-        G1Projective, G2Affine, G2Compressed, G2Prepared, G2Projective, Gt, Scalar,
+        Bls12, Bls12381G1 as InnerBls12381G1, Bls12381G2 as InnerBls12381G2, G1Affine,
+        G1Compressed, G1Projective, G2Affine, G2Compressed, G2Prepared, G2Projective, Gt, Scalar,
     };
 }

--- a/src/traits/pairings.rs
+++ b/src/traits/pairings.rs
@@ -12,7 +12,8 @@ pub trait Pairing {
             Identifier = IdentifierPrimeField<<Self::PublicKey as Group>::Scalar>,
             Value = ValuePrimeField<<Self::PublicKey as Group>::Scalar>,
         > + core::fmt::Debug
-        + DeserializeOwned;
+        + DeserializeOwned
+        + Default;
     /// The public key group
     type PublicKey: Group + GroupEncoding + Default + Display + ConditionallySelectable;
     /// The public key share
@@ -24,7 +25,8 @@ pub trait Pairing {
         + core::fmt::Debug
         + ConditionallySelectable
         + Serialize
-        + DeserializeOwned;
+        + DeserializeOwned
+        + Default;
     /// The signature group
     type Signature: Group<Scalar = <Self::PublicKey as Group>::Scalar>
         + GroupEncoding
@@ -40,7 +42,8 @@ pub trait Pairing {
         + core::fmt::Debug
         + ConditionallySelectable
         + Serialize
-        + DeserializeOwned;
+        + DeserializeOwned
+        + Default;
     /// The target group from a pairing computation
     type PairingResult: Group + GroupEncoding + Default + Display + ConditionallySelectable;
     /// Compute the pairing based on supplied points


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added conversion from legacy v1 byte format for PublicKeyShare and SignatureShare.
  - Exposed Bls12 type for broader interoperability.
  - PublicKeyShare and SecretKeyShare now provide Default implementations; applicable trait bounds updated to support defaults.

- Documentation
  - Updated changelog (v3.0.0) noting new share conversion methods.

- Chores
  - Released version 3.0.0.
  - Updated dependencies: thiserror to 2.0; migrated vsss-rs to published 5.1.0 with serde feature (replacing path dependency).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->